### PR TITLE
Update build.py for latest nanoemoji

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-nanoemoji >= 0.9.7  # we need latest spec support
+nanoemoji >= 0.9.10  # we need latest spec support
 Brotli>=1.0.9  # for compare sizes
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
The current nanoemoji no longer accepts the optional --config parameter, but instead takes in one or more *.toml config files and builds all the fonts in parallel with a single ninja orchestrating the build. This updates the build.py script so that it continues to work like before.