### PR TITLE
build.py: more than 1 file may be copied from build/ to fonts/

### DIFF
--- a/build.py
+++ b/build.py
@@ -58,8 +58,9 @@ def main():
         after_run = time.monotonic()
         font_files = tuple(build_dir.glob("*.[ot]tf"))
         assert len(font_files) >= 1
-        src, dst = font_files[0], font_dir / (config.stem + font_files[0].suffix)
-        shutil.copy(src, dst)
+        for font_file in font_files:
+            src, dst = font_file, font_dir / (config.stem + font_file.suffix)
+            shutil.copy(src, dst)
         print(f"{after_rmtree - before_rmtree:.1f}s to delete build/")
         print(f"{after_run - after_rmtree:.1f}s to run {' '.join(cmd)}")
 


### PR DESCRIPTION
When I updated build.py to support the new nanoemoji (with parallel config inputs) I forgot to also update the lines where the script copies the built fonts to destination. Only the first one was being copied.. :sweat_smile: 

We need to rebuild all fonts after this change, I suspect we'll see some diffs that we didn't catch the last time we run the (broken) build.py.